### PR TITLE
Move rides query before summary stats

### DIFF
--- a/src/pages/RidesPage.tsx
+++ b/src/pages/RidesPage.tsx
@@ -38,16 +38,6 @@ export const RidesPage: React.FC = () => {
   const pageSize = 20;
 
   const queryClient = useQueryClient();
-
-  // Summary statistics
-  const summaryData = React.useMemo(() => {
-    if (!ridesData) return null;
-    const requested = ridesData.rides.filter(r => r.status === 'REQUESTED').length;
-    const unassigned = ridesData.rides.filter(r => !r.driver_id).length;
-    const active = ridesData.rides.filter(r => ['ASSIGNED', 'ENROUTE', 'STARTED'].includes(r.status)).length;
-    return { requested, unassigned, active };
-  }, [ridesData]);
-
   const { data: ridesData, isLoading } = useQuery({
     queryKey: ['rides', searchTerm, statusFilter, unassignedOnly, currentPage],
     queryFn: async (): Promise<{ rides: RideWithRelations[]; total: number }> => {
@@ -85,6 +75,15 @@ export const RidesPage: React.FC = () => {
       };
     },
   });
+
+  // Summary statistics
+  const summaryData = React.useMemo(() => {
+    if (!ridesData) return null;
+    const requested = ridesData.rides.filter(r => r.status === 'REQUESTED').length;
+    const unassigned = ridesData.rides.filter(r => !r.driver_id).length;
+    const active = ridesData.rides.filter(r => ['ASSIGNED', 'ENROUTE', 'STARTED'].includes(r.status)).length;
+    return { requested, unassigned, active };
+  }, [ridesData]);
 
   const assignDriverMutation = useMutation({
     mutationFn: async ({ rideId, driverId }: { rideId: string; driverId: string }) => {


### PR DESCRIPTION
## Summary
- Move rides query hook above summary data memo to ensure data available before calculating stats
- Preserve summary memo dependency on `ridesData`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unexpected any, unused vars, duplicate case, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bff44180648329a5e16c88cd0f1d4d