### PR TITLE
chore: remove unused toast import

### DIFF
--- a/src/pages/Bookkeeping/TransactionsPage.tsx
+++ b/src/pages/Bookkeeping/TransactionsPage.tsx
@@ -2,8 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getEntriesForTxn, getTotalsForTxns, listAccounts, listLedgerTransactions } from '../../lib/api';
 import { Layout } from '../../components/ui/Layout';
-import type { UUID, LedgerTransaction, LedgerEntry, Account } from '../../lib/types';
-import toast from 'react-hot-toast';
+import type { UUID, LedgerEntry, Account } from '../../lib/types';
 
 export default function TransactionsPage() {
   const [page, setPage] = useState(0);


### PR DESCRIPTION
## Summary
- remove unused `toast` and `LedgerTransaction` imports from TransactionsPage

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars in other files)*
- `npx eslint src/pages/Bookkeeping/TransactionsPage.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bff60ece24832993e337fed024a336